### PR TITLE
이승현 / 6 & 7주차

### DIFF
--- a/이승현/7주차/BOJ_11659.java
+++ b/이승현/7주차/BOJ_11659.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class BOJ_11659 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] NM = br.readLine().split(" ");
+        int N = Integer.parseInt(NM[0]);
+        int M = Integer.parseInt(NM[1]);
+
+        int[] nums = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        int[] prefixSum = new int[N];
+        prefixSum[0] = nums[0];
+        for(int i = 1; i < N; i++) {
+            prefixSum[i] = prefixSum[i-1] + nums[i];
+        }
+
+        for(int i = 0; i < M; i++) {
+            String[] ab = br.readLine().split(" ");
+            int a = Integer.parseInt(ab[0]);
+            int b = Integer.parseInt(ab[1]);
+            if(a == 1) {
+                System.out.println(prefixSum[b-1]);
+            } else {
+                int sum = prefixSum[b-1] - prefixSum[a-2];
+                System.out.println(sum);
+            }
+        }
+    }
+}

--- a/이승현/7주차/BOJ_2164.java
+++ b/이승현/7주차/BOJ_2164.java
@@ -1,0 +1,26 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BOJ_2164 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        Queue<Integer> queue = new LinkedList<>();
+
+        for(int i = 1; i <= N; i++) {
+            queue.add(i);
+        }
+
+        for(int i = 0; i < N-1; i++) {
+            queue.poll();
+            int front = queue.poll();
+            queue.add(front);
+        }
+
+        System.out.println(queue.poll());
+    }
+}

--- a/이승현/7주차/BOJ_2751.java
+++ b/이승현/7주차/BOJ_2751.java
@@ -1,0 +1,26 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_2751 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+        ArrayList<Integer> list = new ArrayList<>();
+
+        for(int i = 0; i < N; i++) {
+            list.add(Integer.parseInt(br.readLine()));
+        }
+
+        Collections.sort(list);
+
+        for(int value : list) {
+            sb.append(value).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 6주차
### 10828

10828 / silver 4 / https://www.acmicpc.net/problem/10828

- push X: 정수 X를 스택에 넣는 연산이다.
- pop: 스택에서 가장 위에 있는 정수를 빼고, 그 수를 출력한다. 만약 스택에 들어있는 정수가 없는 경우에는 -1을 출력한다.
- size: 스택에 들어있는 정수의 개수를 출력한다.
- empty: 스택이 비어있으면 1, 아니면 0을 출력한다.
- top: 스택의 가장 위에 있는 정수를 출력한다. 만약 스택에 들어있는 정수가 없는 경우에는 -1을 출력한다.
- Scanner 말고 BufferReader를 사용해야 시간초과가 발생하지 않음
- 슈도 코드
    
    ```java
    N(명령 수)
    Stack<String> stack = new Stack<>();
    
    for(int i = 0; i < N; i++) {
    	str = 문자열 입력
    	command = str.split(" ")
    	if(command[0] == "push") {
    		stack.push(command[1])
    	} else if(command[0] == "pop") {
    		stack.pop() 출력
    	} else if(command[0] == "size") {
    		stack.size() 출력
    	} else if(command[0] == "empty") {
    		stack.isEmpty() 출력
    	} else if(command[0] == "top") {
    		stack.peek() 출력
    	}
    }
    
    ```
    

### 9012

9012 / silver 5 / https://www.acmicpc.net/problem/9012

- VPS인지 확인하기
- 열린 괄호는 push하고 닫힌 괄호일 때는 pop하는 스택 사용
- 슈도 코드
    
    ```java
    T(테스트 데이터 개수)
    
    for(i 0 ... T) {
    	open = 0
    	close = 0
    	PS = 입력
    	
    	for(i 0 ... T) {
    		if(checkBalanced(PS)) {
    			"YES" 출력
    			} else  {
    			"NO" 출력
    		}
    	}
    }
    
    boolean checkBalanced(String string) {
    	for(c : string.toCharArray) {
    		if(c == '(') {
    			stack.push(c)
    		} else if (c == ')') {
    			if(stack.isEmpty()) {
    				return false
    			}
    			stack.pop(c)
    		}
    		
    	return stack.isEmpty()
    	}
    }
    ```
    

### 2108

2108 / silver 3 / https://www.acmicpc.net/problem/2108

- N(홀수)개의 수가 주어진다.
- 산술평균: 모든 수를 더하고 개수만큼 나눔
- 중앙값: 오름차순으로 정렬하고 N-1/2 번째 값
- 최빈값: N개의 수들 중 가장 많이 나타나느
- 범위: 오름차순으로 정렬하고 마지막 인덱스값과 처음 인덱스값의 차
- 알고리즘:
    - 산술평균은 입력받으면서 그때그때 합 구하기
    - arr 배열:
        - 길이 = N
        - 입력받으면서 차례대로 저장
        - 오름차순하고 중앙값(N-1/2의 값)과 범위(처음과 끝값의 차) 구하기
    - count 배열:
        - 길이 8001 (-4000 ~ +4000)
        - arr배열 돌면서 count배열 증가시키기
        - count배열 돌면서 값이 최댓값인 인덱스를 modes 리스트에 추가
        - modes 리스트는 오름차순이므로 원소가 2개이상이면 두번째 것이 최빈값

## 7주차
### 2164

2164 / silver 4 / https://www.acmicpc.net/problem/2164

- 알고리즘
    1. 1부터 N까지 순서대로 큐에 offer
    2. 큐 poll 실행
    3. fornt에 있는 값을 한번 더 poll 해서 따로 저장
    4. 따로 저장한 값 다시 offer
    5. 이 과정을 N-1번 반복하면 한 카드만 남음
- 슈도코드
    
    ```java
    N 입력
    
    for(i = 1 ... <= N) {
    	queue.offer(i)
    }
    
    for(i = 0 ... < N-1) {
    	queue.poll()
    	front = queue.poll()
    	queue.add(front)
    }
    
    queue.poll() 출력
    ```
    

### 11659

11659 / silver 3 / https://www.acmicpc.net/problem/11659

- 알고리즘
    1. 크기가 N인 배열에 입력순으로 숫자들을 저장하면서 누적합도 다른배열에 추가로 저장
    2. M개의 구간합을 구하고 출력
- 누적합을 이용하면 시간복잡도가 O(1)로 매우 효율적이다.
- 처음에는 그냥 반복문으로 부분합을 구했는데 시간초과가 나서 누적합으로 다시 구하니까 성공했다.
- 슈도 코드
    
    ```java
    N(숫자 개수) M(구간합 횟수)
    num[N] 입력
    prefixSum[N] 선언
    prefixSum[0] = num[0]
    
    for(i = 1 ... < N) {
    	prefixSum[i] = prefixSum[i-1] + sum[i]
    }
    
    for(i = 0 ... < M) {
    	a = 입력
    	b = 입력
    	sum = prefixSum[b-1] - prefixSum[a-1]
    	sum 출력
    }
    ```
    

### 2751

2751 / silver 5 / https://www.acmicpc.net/problem/2751

- 자바에 있는 `Arrays.sort()`를 사용하면 시간초과가 발생한다.
    - 퀵정렬 사용
    - 시간복잡도: 평균 `O(n logn)`, worst `O(n^2)`
- 이외에 `Arrays.parallelSort()`를 사용해도 시간초과는 계속 발생한다.
    - 병합정렬 사용
    - 시간복잡도: 평균 `O(n logn)`

- 따라서 문제를 풀 수 있는 방법은 두가지이다.
1. Collections.sort()를 사용한다.
    - 팀정렬 사용
    - 시간복잡도: 평균 `O(n logn)`, best `O(n)`
2. 카운팅 정렬을 사용한다.
    - boolean 배열의 크기를 입력가능한 수의 범위만큼 설정한다.
    - 수가 입력되면 그 수의 값을 인덱스로 하고 인덱스값을 true로 한다.
- **주의할 점**
    - `System.out.println()`이 반복 호출되면서 출력 작업이 많아지기 때문에 더 많은 시간이 소요될 수 있다.
    - 따라서 `StringBuilder sb = new StringBuilder()` 를 사용하여 결과를 한번에 출력하는 것이 더 빠르다.
- 참고: https://st-lab.tistory.com/106

## 스택과 큐

### 스택

- 스택은 삽입과 삭제 연산이 후입선출(LIFO)로 이뤄지는 자료구조이다.
- 후입선출은 삽입과 삭제가 한 쪽에서만 일어나는 특징이 있다.

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/ddddc4a0-9f8a-4f78-a27c-255985fee0f3/c731149a-5f2d-4704-b3ce-4f75917ded0a/Untitled.png)

- 새 값이 스택에 들어가면 top이 새 값을 가리킨다.
- 스택에서 값을 뺄 때 top이 가리키는 값을 스택에서 빼게 되어 있으므로 가장 마지막에 넣었던 값이 나오게 된다.

> **스택 용어**
> 
> - **위치**
>     - top: 삽입과 삭제가 일어나는 위치를 뜻한다.
> - **연산**
>     - push: top 위치에 새로운 데이터를 삽입하는 연산이다.
>     - pop: top 위치에 현재 있는 데이터를 삭제하고 확인하는 연산이다.
>     - peek: top 위치에 현재 있는 데이터를 단순 확인하는 연산이다.
- 스택은 깊이 우선 탐색, 백트래킹 종류의 코딩 테스트에 효과적이므로 반드시 알아 두어야 한다.
- 후입선출은 개념 자체가 재귀 함수 알고리즘 원리와 일맥상통하기 때문이다.

### 큐

- 큐는 삽입과 삭제 연산이 선입선출(FIFO)로 이뤄지는 자료구조이다.
- 스택과 다르게 먼저 들어온 데이터가 먼저 나간다.
- 삽입과 삭제가 양방향에서 이뤄진다.

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/ddddc4a0-9f8a-4f78-a27c-255985fee0f3/7765d8db-705b-47ed-b5e8-aed4ff647396/Untitled.png)

- 새 값 추가는 큐의 rear에서 이뤄지고, 삭제는 큐의 front에서 이뤄진다.

> **큐 용어**
> 
> - rear: 큐에서 가장 끝 데이터를 가리키는 영역이다.
> - front: 큐에서 가장 앞의 데이터를 가리키는 영역이다.
> - add: rear 부분에 새로운 데이터를 삽입하는 연산이다.
> - poll: front 부분에 있는 데이터를 삭제하고 확인하는 연산이다.
> - peek: 큐의 맨 앞(front)에 있는 데이터를 확인할 때 사용하는 연산이다.
- 큐는 너비 우선 탐색에서 자주 사용되므로 이 역시도 스택과 함께 잘 알아두어야 하는 개념이다.

<aside>
💡 **우선순위 큐도 있다!**
우선순위 큐는 값이 들어간 순서와 상관 없이 우선순위가 높은 데이터가 먼저 나오는 자료구조이다. 큐 설정에 따라 front에 항상 최댓값 또는 최솟값이 위치한다. 우선순위 큐는 일반적으로 힙(heap)을 이용해 구현하는데 힙은 트리 종류 중 하나이다.

</aside>

### 자바에서 스택 사용법

1. 자바에서 스택을 사용하기 위해 `java.util` 패키지의 `Stack` 클래스를 `import`한다.

```java
import java.util.Stack;
```

1. `Stack` 객체를 생성한다.

```java
Stack<String> stack = new Stack<>();
```

1. 스택에 데이터를 추가하기 위해 `push` 메소드를 사용한다.

```java
stack.push("데이터1");
stack.push("데이터2");
stack.push("데이터3");
```

1. 스택에서 데이터를 꺼내기 위해 `pop` 메소드를 사용한다.

```java
String data = stack.pop();
System.out.println(data); // "데이터3"
```

- `pop` 메소드는 스택에서 가장 위에 있는 데이터를 꺼내고, 해당 데이터를 반환한다. 스택에서 꺼낸 데이터는 스택에서 제거된다.
1. 스택에서 데이터를 확인하기 위해 `peek` 메소드를 사용할 수 있다. `peek` 메소드는 스택의 가장 위에 있는 데이터를 반환하지만, 스택에서 제거하지는 않.ㄷ다.

```java
String topData = stack.peek();
System.out.println(topData); // "데이터2"
```

- `peek` 메소드를 사용하면 스택의 가장 위에 있는 데이터를 확인할 수 있다.
1. 스택이 비어있는지 확인하기 위해 `isEmpty` 메소드를 사용할 수 있다.

```java
boolean isEmpty = stack.isEmpty();
System.out.println(isEmpty); // false
```

- `isEmpty` 메소드는 스택이 비어있으면 `true`를, 데이터가 있는 경우 `false`를 반환한다.
- 위와 같은 방법으로 자바에서 스택을 활용할 수 있습니다. 스택은 데이터의 추가와 제거가 상수 시간(O(1))에 이루어지기 때문에, 데이터를 임시로 저장하거나 역순으로 처리해야 할 때 유용하게 사용된다.

### 자바에서 큐 사용법

1. 자바에서 큐를 사용하기 위해 `java.util` 패키지의 `Queue` 인터페이스를 `import` 해야 한다.

```java
import java.util.Queue;
```

1. 큐를 구현한 클래스 중 하나인 `LinkedList`를 사용하여 `Queue` 객체를 생성한다.

```java
Queue<String> queue = new LinkedList<>();
```

1. 큐에 데이터를 추가하기 위해 `offer` 메소드를 사용한다.

```java
queue.offer("데이터1");
queue.offer("데이터2");
queue.offer("데이터3");
```

1. 큐에서 데이터를 꺼내기 위해 `poll` 메소드를 사용한다.

```java
String data = queue.poll();
System.out.println(data); // "데이터1"
```

- `poll` 메소드는 큐에서 가장 앞에 있는 데이터를 꺼내고, 해당 데이터를 반환합니다. 큐에서 꺼낸 데이터는 큐에서 제거된다.
1. 큐에서 데이터를 확인하기 위해 `peek` 메소드를 사용할 수 있다. `peek` 메소드는 큐의 가장 앞에 있는 데이터를 반환하지만, 큐에서 제거하지는 않는다.

```java
String frontData = queue.peek();
System.out.println(frontData); // "데이터2"
```

1. 큐가 비어있는지 확인하기 위해 `isEmpty` 메소드를 사용할 수 있다.

```java
boolean isEmpty = queue.isEmpty();
System.out.println(isEmpty); // false
```

- `isEmpty` 메소드는 큐가 비어있으면 `true`를, 데이터가 있는 경우 `false`를 반환한다.
- 위와 같은 방법으로 자바에서 큐를 활용할 수 있다. 큐는 데이터를 순서대로 처리해야 할 때 유용하게 사용되며, 주로 작업 대기열, 이벤트 처리, 너비 우선 탐색(BFS) 등에 활용된다.